### PR TITLE
first draft experiment_level_metadata

### DIFF
--- a/conf/schema.json
+++ b/conf/schema.json
@@ -145,7 +145,7 @@
             "panel_id",
             "experiment_sample_id"
         ],
-        "alternatives": {
+        "required_alternatives": {
             "sequencing_info_id": [
                 "seq_info_id",
                 "sequencing_id",
@@ -172,6 +172,26 @@
                 "sequencing_id",
                 "extraction_id",
                 "run_accession"
+            ]
+        },
+        "optional": [
+            "accession",
+            "plate_col",
+            "plate_name",
+            "plate_row"
+        ],
+        "optional_alternatives": {
+            "accession": [
+                "Accession information"
+            ],
+            "plate_col": [
+                "plate_column"
+            ],
+            "plate_name": [
+                "name_of_plate"
+            ],
+            "plate_row": [
+                "row_of_plate"
             ]
         }
     },

--- a/pages/1_Panel_Information.py
+++ b/pages/1_Panel_Information.py
@@ -2,7 +2,7 @@ import streamlit as st
 import json
 import os
 from src.data_loader import load_csv
-from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section
+from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section, add_additional_fields
 from src.transformer import transform_panel_info
 from src.format_page import render_header
 from src.utils import load_schema
@@ -70,22 +70,6 @@ class PanelPage:
             field_mapping, df.columns.tolist())
         return field_mapping, unused_field_names
 
-    def add_additional_fields(self, unused_field_names):
-        st.subheader("Add Additional Fields")
-        selected_additional_fields = None
-        if unused_field_names:
-            optional_additional_fields = st.toggle(
-                "Add additional fields from your table")
-            if optional_additional_fields:
-                checkbox_states = {}
-                st.write("Select the extra columns you would like to include:")
-                for item in unused_field_names:
-                    checkbox_states[item] = st.checkbox(label=item)
-                selected_additional_fields = [
-                    key for key, value in checkbox_states.items() if value]
-                st.write("You selected:", selected_additional_fields)
-        return selected_additional_fields
-
     def add_genome_information(self):
         st.subheader("Add Genome Information")
         genome_name = st.text_input("Name:", help='Name of the genome.')
@@ -144,7 +128,7 @@ class PanelPage:
             field_mapping, unused_field_names = self.field_mapping(df)
 
             # Add additional fields
-            selected_additional_fields = self.add_additional_fields(
+            selected_additional_fields = add_additional_fields(
                 unused_field_names)
 
             # Add genome information

--- a/pages/2_Specimen_Level_Metadata.py
+++ b/pages/2_Specimen_Level_Metadata.py
@@ -1,63 +1,16 @@
 import streamlit as st
 from src.format_page import render_header
-from src.data_loader import load_csv
-from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section
+from src.field_matcher import load_data
 from src.transformer import transform_specimen_info
 from src.utils import load_schema
 
-
 class SpecimenMetadataPage:
-    def __init__(self, target_schema, alternate_schema_names):
-        self.target_schema = target_schema
-        self.alternate_schema_names = alternate_schema_names
-
-    def upload_csv(self):
-        st.subheader("Upload File")
-        return st.file_uploader("Upload a TSV file", type=["csv", "tsv", "xlsx", "xls", "txt"])
-
-    def field_mapping(self, df):
-        # Fuzzy field matching required arguments
-        mapped_fields, unused_field_names = fuzzy_field_matching_page_section(
-            df, self.target_schema, self.alternate_schema_names)
-
-        # Interactive field mapping
-        mapped_fields = interactive_field_mapping_page_section(
-            mapped_fields, df.columns.tolist())
-        return mapped_fields, unused_field_names
-
-    def add_additional_fields(self, unused_field_names):
-        st.subheader("Add Additional Fields")
-        selected_additional_fields = None
-        if unused_field_names:
-            optional_additional_fields = st.toggle("Add additional fields")
-            if optional_additional_fields:
-                checkbox_states = {}
-                st.write("Select the extra columns you would like to include:")
-                for item in unused_field_names:
-                    checkbox_states[item] = st.checkbox(label=item)
-                selected_additional_fields = [
-                    key for key, value in checkbox_states.items() if value]
-                st.write("You selected:", selected_additional_fields)
-        return selected_additional_fields
-
-    def add_optional_fields(self, df, unused_field_names):
-        st.subheader("Add Optional Fields")
-        mapped_fields = {key:None for key in schema_fields["specimen_level_metadata"]["optional"]}
-        if unused_field_names:
-            new_df=df[unused_field_names]
-            # Fuzzy field matching optional arguments
-            mapped_fields, junk = fuzzy_field_matching_page_section(
-                new_df, schema_fields["specimen_level_metadata"]["optional"], 
-                schema_fields["specimen_level_metadata"]["optional_alternatives"])
-
-            #Interactive field mapping optional arguments
-            mapped_fields = interactive_field_mapping_page_section(
-                mapped_fields, new_df.columns.tolist(), "Manually Alter Field Mapping of optional arguments")
-        for key in mapped_fields:
-            if mapped_fields[key]=='no match':
-                mapped_fields[key]=None
-        remaining_unused=list(set(unused_field_names)-set(mapped_fields.values()))
-        return mapped_fields, remaining_unused
+    def __init__(self, required_fields, required_alternate_fields,
+        optional_fields, optional_alternate_fields):
+        self.required_fields = required_fields
+        self.required_alternate_fields = required_alternate_fields
+        self.optional_fields = optional_fields
+        self.optional_alternate_fields = optional_alternate_fields
 
     def transform_and_save_data(self, df, mapped_fields, selected_optional_fields, selected_additional_fields):
         st.subheader("Transform Data")
@@ -69,35 +22,25 @@ class SpecimenMetadataPage:
                 st.success(
                     f"Specimen Information has been saved!")
             except Exception as e:
-                st.error(f"Error saving Microhaplotype Information: {e}")
+                st.error(f"Error saving Specimen Information: {e}")
 
     def run(self):
-        # File upload
-        uploaded_file = self.upload_csv()
-        if uploaded_file:
-            df = load_csv(uploaded_file)
-            interactive_preview = st.toggle("Preview File")
-            if interactive_preview:
-                st.write("Uploaded File Preview:")
-                st.dataframe(df)
-
-            mapped_fields, unused_field_names = self.field_mapping(df)
-            # Add optional fields
-            selected_optional_fields, unused_field_names = self.add_optional_fields(df,
-                unused_field_names)
-            # Add additional fields
-            selected_additional_fields = self.add_additional_fields(unused_field_names)
-
-            # Transform and save data
-            self.transform_and_save_data(
-                df, mapped_fields, selected_optional_fields, selected_additional_fields)
-
+        df, mapped_fields, selected_optional_fields, selected_additional_fields=load_data(
+            required_fields, required_alternate_fields, optional_fields,
+            optional_alternate_fields)
+        # Transform and save data
+        if mapped_fields:
+            self.transform_and_save_data(df, mapped_fields,
+                selected_optional_fields, selected_additional_fields)
 
 if __name__ == "__main__":
     render_header()
     st.subheader("Specimen Level Metadata Converter", divider="gray")
     schema_fields = load_schema()
-    target_schema = schema_fields["specimen_level_metadata"]["required"]
-    alternate_schema_names = schema_fields["specimen_level_metadata"]["required_alternatives"]
-    app = SpecimenMetadataPage(target_schema, alternate_schema_names)
+    required_fields = schema_fields["specimen_level_metadata"]["required"]
+    required_alternate_fields = schema_fields["specimen_level_metadata"]["required_alternatives"]
+    optional_fields = schema_fields["specimen_level_metadata"]["optional"]
+    optional_alternate_fields = schema_fields["specimen_level_metadata"]["optional_alternatives"]
+    app = SpecimenMetadataPage(required_fields, required_alternate_fields,
+        optional_fields, optional_alternate_fields)
     app.run()

--- a/pages/3_Experiment_Level_Metadata.py
+++ b/pages/3_Experiment_Level_Metadata.py
@@ -1,83 +1,47 @@
 import streamlit as st
 from src.format_page import render_header
-from src.data_loader import load_csv
-from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section
+from src.field_matcher import load_data
 from src.transformer import transform_experiment_info
 from src.utils import load_schema
 
 
 class ExperimentMetadataPage:
-    def __init__(self, target_schema, alternate_schema_names):
-        self.target_schema = target_schema
-        self.alternate_schema_names = alternate_schema_names
+    def __init__(self, required_fields, required_alternate_fields,
+        optional_fields, optional_alternate_fields):
+        self.required_fields = required_fields
+        self.required_alternate_fields = required_alternate_fields
+        self.optional_fields = optional_fields
+        self.optional_alternate_fields = optional_alternate_fields
 
-    def upload_csv(self):
-        st.subheader("Upload File")
-        return st.file_uploader("Upload a TSV file", type=["csv", "tsv", "xlsx", "xls", "txt"])
-
-    def field_mapping(self, df):
-        # Fuzzy field matching
-        field_mapping, unused_field_names = fuzzy_field_matching_page_section(
-            df, self.target_schema, self.alternate_schema_names)
-
-        # Interactive field mapping
-        field_mapping = interactive_field_mapping_page_section(
-            field_mapping, df.columns.tolist())
-        return field_mapping, unused_field_names
-
-    def add_additional_fields(self, unused_field_names):
-        st.subheader("Add Additional Fields")
-        selected_additional_fields = None
-        if unused_field_names:
-            optional_additional_fields = st.toggle("Add additional fields")
-            if optional_additional_fields:
-                checkbox_states = {}
-                st.write("Select the extra columns you would like to include:")
-                for item in unused_field_names:
-                    checkbox_states[item] = st.checkbox(label=item)
-                selected_additional_fields = [
-                    key for key, value in checkbox_states.items() if value]
-                st.write("You selected:", selected_additional_fields)
-        return selected_additional_fields
-
-    def transform_and_save_data(self, df, field_mapping, selected_additional_fields):
+    def transform_and_save_data(self, df, field_mapping, 
+        selected_optional_fields, selected_additional_fields):
         st.subheader("Transform Data")
         if st.button("Transform Data"):
-            transformed_df = transform_experiment_info(
-                df, field_mapping, selected_additional_fields)
+            transformed_df = transform_experiment_info(df, field_mapping,
+                selected_optional_fields, selected_additional_fields)
             st.session_state["experiment_info"] = transformed_df
             try:
                 st.success(
-                    f"Specimen Information has been saved!")
+                    f"Experiment Information has been saved!")
             except Exception as e:
-                st.error(f"Error saving Microhaplotype Information: {e}")
+                st.error(f"Error saving Experiment Information: {e}")
 
     def run(self):
         # File upload
-        uploaded_file = self.upload_csv()
-        if uploaded_file:
-            df = load_csv(uploaded_file)
-            interactive_preview = st.toggle("Preview File")
-            if interactive_preview:
-                st.write("Uploaded File Preview:")
-                st.dataframe(df)
-
-            field_mapping, unused_field_names = self.field_mapping(df)
-
-            # Add additional fields
-            selected_additional_fields = self.add_additional_fields(
-                unused_field_names)
-
+        df, mapped_fields, selected_optional_fields, selected_additional_fields=load_data(
+            required_fields, required_alternate_fields, optional_fields,
+            optional_alternate_fields)
             # Transform and save data
-            self.transform_and_save_data(
-                df, field_mapping, selected_additional_fields)
-
+        self.transform_and_save_data(df, mapped_fields,
+            selected_optional_fields, selected_additional_fields)
 
 if __name__ == "__main__":
     render_header()
     st.subheader("Experiment Level Metadata Converter", divider="gray")
     schema_fields = load_schema()
-    target_schema = schema_fields["experiment_level_metadata"]["required"]
-    alternate_schema_names = schema_fields["experiment_level_metadata"]["alternatives"]
-    app = ExperimentMetadataPage(target_schema, alternate_schema_names)
+    required_fields = schema_fields["experiment_level_metadata"]["required"]
+    required_alternate_fields = schema_fields["experiment_level_metadata"]["required_alternatives"]
+    optional_fields = schema_fields["experiment_level_metadata"]["optional"]
+    optional_alternate_fields = schema_fields["experiment_level_metadata"]["optional_alternatives"]
+    app = ExperimentMetadataPage(required_fields, required_alternate_fields, optional_fields, optional_alternate_fields)
     app.run()

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -53,17 +53,21 @@ def transform_specimen_info(df, field_mapping, optional_field_mapping, additiona
     return transformed_df
 
 
-def transform_experiment_info(df, field_mapping, additional_fields=None):
+def transform_experiment_info(df, field_mapping, optional_mapping,
+    additional_fields=None):
     transformed_df = experiment_info_table_to_json(
         df,
         experiment_sample_id_col=field_mapping["experiment_sample_id"],
         sequencing_info_id=field_mapping["sequencing_info_id"],
         specimen_id=field_mapping["specimen_id"],
         panel_id=field_mapping["panel_id"],
+        accession=optional_mapping["accession"],
+        plate_col=optional_mapping["plate_col"],
+        plate_name=optional_mapping["plate_name"],
+        plate_row=optional_mapping["plate_row"],
         additional_experiment_cols=additional_fields
     )
     return transformed_df
-
 
 def transform_demultiplexed_info(df, bioinfo_id, field_mapping, additional_hap_detected_cols=None):
     """Reformat the DataFrame based on the provided field mapping."""


### PR DESCRIPTION
Moves field matching (including required, optional, and additional fields) from each individual page into the shared field_matcher module. This standardizes the web pages so that each one is performing the same loading functions. More specifically:

1. upload_csv, field_mapping, add_optional_fields, and add_additional_fields functions moved to field_matcher module (these could all become a Class or even a discrete module, but I left them as functions) (did this on specimen level metadata and experiment level metadata)
2. Edited the schema.json files associated with experiment level metadata and made calls to these fields in the main body of the experiment level metadata page.
3. Edited the transform_experiment_info from transformer.py to pass these optional arguments

Still to come: finalizing page 1, page 4, and page 5 to implement