### PR TITLE
Optional arguments alt 1

### DIFF
--- a/conf/schema.json
+++ b/conf/schema.json
@@ -5,7 +5,7 @@
             "forward_primers",
             "reverse_primers"
         ],
-        "alternatives": {
+        "required_alternatives": {
             "target_id": [
                 "locus",
                 "amplicon",
@@ -18,6 +18,62 @@
             "reverse_primers": [
                 "rev_primers",
                 "ligation_arm"
+            ]
+        },
+        "optional": [
+            "forward_primers_start_col",
+            "forward_primers_end_col",
+            "reverse_primers_start_col",
+            "reverse_primers_end_col",
+            "insert_start_col",
+            "insert_end_col",
+            "chrom_col",
+            "strand_col",
+            "gene_id_col",
+            "target_type_col"
+        ],
+        "optional_alternatives": {
+            "forward_primers_start_col": [
+                "genomic_forward_primer_start",
+                "forward_primer_genomic_start_coordinate"
+            ],
+            "forward_primers_end_col": [
+                "genomic_forward_primer_end",
+                "forward_primer_genomic_end_coordinate"
+            ],
+            "reverse_primers_start_col": [
+                "genomic_reverse_primer_start",
+                "reverse_primer_genomic_start_coordinate"
+            ],
+            "reverse_primers_end_col": [
+                "genomic_reverse_primer_end",
+                "reverse_primer_genomic_end_coordinate"
+            ],
+            "insert_start_col": [
+                "genomic_insert_start",
+                "insert_genomic_start_coordinate"
+            ],
+            "insert_end_col": [
+                "genomic_insert_end",
+                "insert_genomic_end_coordinate"
+            ],
+            "chrom_col": [
+                "chromosome",
+                "amplicon_chrom",
+                "gene_chrom"
+            ],
+            "strand_col": [
+                "amplicon_strand",
+                "gene_strand",
+                "gene_genomic_strand"
+            ],
+            "gene_id_col": [
+                "gene_name",
+                "amplicon_gene"
+            ],
+            "target_type_col": [
+                "gene_type",
+                "amplicon_type"
             ]
         }
     },

--- a/conf/schema.json
+++ b/conf/schema.json
@@ -202,7 +202,7 @@
             "asv",
             "reads"
         ],
-        "alternatives": {
+        "required_alternatives": {
             "sampleID": [
                 "specimen_id",
                 "sample_id",
@@ -231,6 +231,10 @@
                 "c_barcodeCnt",
                 "c_readCnt"
             ]
+        },
+        "optional": [
+        ],
+        "optional_alternatives": {
         }
     },
     "demultiplexed_samples": {
@@ -239,7 +243,7 @@
             "target_id",
             "raw_read_count"
         ],
-        "alternatives": {
+        "required_alternatives": {
             "sampleID": [
                 "specimen_id",
                 "sample_id",
@@ -258,6 +262,10 @@
                 "demuliplexed",
                 "demuliplexed_read_count"
             ]
+        },
+        "optional": [
+        ],
+        "optional_alternatives": {
         }
     },
     "sequencing_info": {

--- a/conf/schema.json
+++ b/conf/schema.json
@@ -32,7 +32,7 @@
             "samp_collect_device",
             "project_name"
         ],
-        "alternatives": {
+        "required_alternatives": {
             "specimen_id": [
                 "sample_id",
                 "bio_id",
@@ -76,6 +76,65 @@
                 "study_name",
                 "research_project",
                 "experiment_name"
+            ]
+        },
+        "optional": [
+            "alternate_identifiers",
+            "geo_admin1",
+            "geo_admin2",
+            "geo_admin3",
+            "host_taxon_id",
+            "individual_id",
+            "lat_lon",
+            "parasite_density",
+            "plate_col",
+            "plate_name",
+            "plate_row",
+            "sample_comments"
+        ],
+        "optional_alternatives": {
+            "alternate_identifiers": [
+                "alternate identifiers",
+                "alternate_IDs"
+            ],
+            "geo_admin1": [
+                "Region",
+                "State",
+                "District"
+            ],
+            "geo_admin2": [
+                "District",
+                "county"
+            ],
+            "geo_admin3": [
+                "City"
+            ],
+            "host_taxon_id": [
+                "host_species_ID",
+                "host_taxon_ID"
+            ],
+            "individual_id": [
+                "individual_ID"
+            ],
+            "lat_lon": [
+                "latitude_longitude"
+            ],
+            "parasite_density": [
+                "parasitemia",
+                "parasites/ul"
+            ],
+            "plate_col": [
+                "plate_column",
+                "column_number"
+            ],
+            "plate_name": [
+                "plate_number"
+            ],
+            "plate_row": [
+                "row_number"
+            ],
+            "sample_comments": [
+                "additional_sample_info"
             ]
         }
     },

--- a/conf/schema.json
+++ b/conf/schema.json
@@ -145,7 +145,7 @@
             "panel_id",
             "experiment_sample_id"
         ],
-        "alternatives": {
+        "required_alternatives": {
             "sequencing_info_id": [
                 "seq_info_id",
                 "sequencing_id",
@@ -172,6 +172,26 @@
                 "sequencing_id",
                 "extraction_id",
                 "run_accession"
+            ]
+        },
+        "optional": [
+            "accession",
+            "plate_col",
+            "plate_name",
+            "plate_row"
+        ],
+        "optional_alternatives": {
+            "accession": [
+                "Accession information"
+            ],
+            "plate_col": [
+                "plate_column"
+            ],
+            "plate_name": [
+                "name_of_plate"
+            ],
+            "plate_row": [
+                "row_of_plate"
             ]
         }
     },

--- a/pages/1_Panel_Information.py
+++ b/pages/1_Panel_Information.py
@@ -1,8 +1,7 @@
 import streamlit as st
 import json
 import os
-from src.data_loader import load_csv
-from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section, add_additional_fields
+from src.field_matcher import load_data
 from src.transformer import transform_panel_info
 from src.format_page import render_header
 from src.utils import load_schema
@@ -31,12 +30,15 @@ class PanelManager:
 
 
 class PanelPage:
-    def __init__(self, save_dir, target_schema, alternate_schema_names):
+    def __init__(self, save_dir, required_fields, required_alternate_fields,
+        optional_fields, optional_alternate_fields):
         self.save_dir = save_dir
         self.panel_manager = PanelManager(self.save_dir)
         self.panel_manager.check_save_dir()
-        self.target_schema = target_schema
-        self.alternate_schema_names = alternate_schema_names
+        self.required_fields = required_fields
+        self.required_alternate_fields = required_alternate_fields
+        self.optional_fields = optional_fields
+        self.optional_alternate_fields = optional_alternate_fields
 
     def load_saved_panel(self):
         use_past = st.checkbox("Use a past version")
@@ -56,20 +58,6 @@ class PanelPage:
         st.subheader("Panel ID")
         return st.text_input("Enter panel ID:", help='Identifier for the panel.')
 
-    def upload_csv(self):
-        st.subheader("Upload File")
-        return st.file_uploader("Upload a TSV file", type=["csv", "tsv", "xlsx", "xls", "txt"])
-
-    def field_mapping(self, df):
-        # Fuzzy field matching
-        field_mapping, unused_field_names = fuzzy_field_matching_page_section(
-            df, self.target_schema, self.alternate_schema_names)
-
-        # Interactive field mapping
-        field_mapping = interactive_field_mapping_page_section(
-            field_mapping, df.columns.tolist())
-        return field_mapping, unused_field_names
-
     def add_genome_information(self):
         st.subheader("Add Genome Information")
         genome_name = st.text_input("Name:", help='Name of the genome.')
@@ -88,12 +76,14 @@ class PanelPage:
             genome_info["gff_url"] = gff_url
         return genome_info
 
-    def transform_and_save_data(self, df, panel_ID, field_mapping, genome_info, selected_additional_fields):
+    def transform_and_save_data(self, df, panel_ID, field_mapping, genome_info, 
+        selected_optional_fields, selected_additional_fields):
         if all([panel_ID, genome_info["name"], genome_info["taxon_id"], genome_info["version"], genome_info["url"]]):
             st.subheader("Transform Data")
             if st.button("Transform Data"):
                 transformed_df = transform_panel_info(
-                    df, panel_ID, field_mapping, genome_info, selected_additional_fields)
+                    df, panel_ID, field_mapping, genome_info,
+                    selected_optional_fields, selected_additional_fields)
                 # json_data = json.dumps(transformed_df, indent=4)
                 st.session_state["panel_info"] = transformed_df
                 try:
@@ -116,27 +106,17 @@ class PanelPage:
         # Input for panel ID
         panel_ID = self.panel_id_input()
 
-        # File upload
-        uploaded_file = self.upload_csv()
-        if uploaded_file:
-            df = load_csv(uploaded_file)
-            interactive_preview = st.toggle("Preview File")
-            if interactive_preview:
-                st.write("Uploaded File Preview:")
-                st.dataframe(df)
+        df, mapped_fields, selected_optional_fields, selected_additional_fields=load_data(
+            required_fields, required_alternate_fields, optional_fields,
+            optional_alternate_fields)
 
-            field_mapping, unused_field_names = self.field_mapping(df)
+        # Add genome information
+        genome_info = self.add_genome_information()
 
-            # Add additional fields
-            selected_additional_fields = add_additional_fields(
-                unused_field_names)
-
-            # Add genome information
-            genome_info = self.add_genome_information()
-
-            # Transform and save data
-            self.transform_and_save_data(
-                df, panel_ID, field_mapping, genome_info, selected_additional_fields)
+        # Transform and save data
+        self.transform_and_save_data(df, panel_ID, mapped_fields,
+            genome_info, selected_optional_fields,
+            selected_additional_fields)
 
         # Display current panel information
         self.display_panel_info()
@@ -147,8 +127,11 @@ if __name__ == "__main__":
     render_header()
     st.subheader("Panel Information Converter", divider="gray")
     schema_fields = load_schema()
-    target_schema = schema_fields["panel_info"]["required"]
-    alternate_schema_names = schema_fields["panel_info"]["alternatives"]
+    required_fields = schema_fields["panel_info"]["required"]
+    required_alternate_fields = schema_fields["panel_info"]["required_alternatives"]
+    optional_fields = schema_fields["panel_info"]["optional"]
+    optional_alternate_fields = schema_fields["panel_info"]["optional_alternatives"]
     app = PanelPage(os.path.join(os.getcwd(), "saved_panels"),
-                    target_schema, alternate_schema_names)
+                    required_fields, required_alternate_fields, optional_fields,
+                    optional_alternate_fields)
     app.run()

--- a/pages/1_Panel_Information.py
+++ b/pages/1_Panel_Information.py
@@ -6,6 +6,9 @@ from src.transformer import transform_panel_info
 from src.format_page import render_header
 from src.utils import load_schema
 
+session_name='panel_info'
+title='panel information'
+
 class PanelManager:
     def __init__(self, save_dir):
         self.save_dir = save_dir
@@ -78,7 +81,7 @@ class PanelPage:
 
     def transform_and_save_data(self, df, panel_ID, field_mapping, genome_info, 
         selected_optional_fields, selected_additional_fields):
-        if all([panel_ID, genome_info["name"], genome_info["taxon_id"], genome_info["version"], genome_info["url"]]):
+        if all([panel_ID, field_mapping, genome_info["name"], genome_info["taxon_id"], genome_info["version"], genome_info["url"]]) and selected_optional_fields!='Error':
             st.subheader("Transform Data")
             if st.button("Transform Data"):
                 transformed_df = transform_panel_info(
@@ -92,17 +95,16 @@ class PanelPage:
                 except Exception as e:
                     st.error(f"Error saving panel: {e}")
 
-    def display_panel_info(self):
-        if "panel_info" in st.session_state:
-            preview = st.toggle("Preview Panel Information")
+    def display_panel_info(self, toggle_text):
+        if session_name in st.session_state:
+            preview = st.toggle(toggle_text)
             if preview:
-                st.write("Current Panel Information:")
-                st.json(st.session_state["panel_info"])
+                st.write(f"Current {title}:")
+                st.json(st.session_state[session_name])
 
     def run(self):
         # Load past panel if applicable
         self.load_saved_panel()
-
         # Input for panel ID
         panel_ID = self.panel_id_input()
 
@@ -119,7 +121,7 @@ class PanelPage:
             selected_additional_fields)
 
         # Display current panel information
-        self.display_panel_info()
+        self.display_panel_info(f"Preview {title}")
 
 
 # Initialize and run the app
@@ -134,4 +136,8 @@ if __name__ == "__main__":
     app = PanelPage(os.path.join(os.getcwd(), "saved_panels"),
                     required_fields, required_alternate_fields, optional_fields,
                     optional_alternate_fields)
+    if session_name in st.session_state:
+        st.success(f'Your {title} has already been saved during a'
+            ' previous run of this page')
+        app.display_panel_info(f"Preview previously stored {title}")
     app.run()

--- a/pages/1_Panel_Information.py
+++ b/pages/1_Panel_Information.py
@@ -2,7 +2,7 @@ import streamlit as st
 import json
 import os
 from src.data_loader import load_csv
-from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section
+from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section, add_additional_fields
 from src.transformer import transform_panel_info
 from src.format_page import render_header
 from src.utils import load_schema
@@ -70,22 +70,6 @@ class PanelPage:
             field_mapping, df.columns.tolist())
         return field_mapping, unused_field_names
 
-    def add_additional_fields(self, unused_field_names):
-        st.subheader("Add Additional Fields")
-        selected_additional_fields = None
-        if unused_field_names:
-            optional_additional_fields = st.toggle(
-                "Add additional fields from your table")
-            if optional_additional_fields:
-                checkbox_states = {}
-                st.write("Select the extra columns you would like to include:")
-                for item in unused_field_names:
-                    checkbox_states[item] = st.checkbox(label=item)
-                selected_additional_fields = [
-                    key for key, value in checkbox_states.items() if value]
-                st.write("You selected:", selected_additional_fields)
-        return selected_additional_fields
-
     def add_genome_information(self):
         st.subheader("Add Genome Information")
         genome_name = st.text_input("Name:", help='Name of the genome.')
@@ -144,7 +128,7 @@ class PanelPage:
             field_mapping, unused_field_names = self.field_mapping(df)
 
             # Add additional fields
-            selected_additional_fields = self.add_additional_fields(
+            selected_additional_fields = add_additional_fields(
                 unused_field_names)
 
             # Add genome information

--- a/pages/2_Specimen_Level_Metadata.py
+++ b/pages/2_Specimen_Level_Metadata.py
@@ -1,63 +1,16 @@
 import streamlit as st
 from src.format_page import render_header
-from src.data_loader import load_csv
-from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section
+from src.field_matcher import load_data
 from src.transformer import transform_specimen_info
 from src.utils import load_schema
 
-
 class SpecimenMetadataPage:
-    def __init__(self, target_schema, alternate_schema_names):
-        self.target_schema = target_schema
-        self.alternate_schema_names = alternate_schema_names
-
-    def upload_csv(self):
-        st.subheader("Upload File")
-        return st.file_uploader("Upload a TSV file", type=["csv", "tsv", "xlsx", "xls", "txt"])
-
-    def field_mapping(self, df):
-        # Fuzzy field matching required arguments
-        mapped_fields, unused_field_names = fuzzy_field_matching_page_section(
-            df, self.target_schema, self.alternate_schema_names)
-
-        # Interactive field mapping
-        mapped_fields = interactive_field_mapping_page_section(
-            mapped_fields, df.columns.tolist())
-        return mapped_fields, unused_field_names
-
-    def add_additional_fields(self, unused_field_names):
-        st.subheader("Add Additional Fields")
-        selected_additional_fields = None
-        if unused_field_names:
-            optional_additional_fields = st.toggle("Add additional fields")
-            if optional_additional_fields:
-                checkbox_states = {}
-                st.write("Select the extra columns you would like to include:")
-                for item in unused_field_names:
-                    checkbox_states[item] = st.checkbox(label=item)
-                selected_additional_fields = [
-                    key for key, value in checkbox_states.items() if value]
-                st.write("You selected:", selected_additional_fields)
-        return selected_additional_fields
-
-    def add_optional_fields(self, df, unused_field_names):
-        st.subheader("Add Optional Fields")
-        mapped_fields = {key:None for key in schema_fields["specimen_level_metadata"]["optional"]}
-        if unused_field_names:
-            new_df=df[unused_field_names]
-            # Fuzzy field matching optional arguments
-            mapped_fields, junk = fuzzy_field_matching_page_section(
-                new_df, schema_fields["specimen_level_metadata"]["optional"], 
-                schema_fields["specimen_level_metadata"]["optional_alternatives"])
-
-            #Interactive field mapping optional arguments
-            mapped_fields = interactive_field_mapping_page_section(
-                mapped_fields, new_df.columns.tolist(), "Manually Alter Field Mapping of optional arguments")
-        for key in mapped_fields:
-            if mapped_fields[key]=='no match':
-                mapped_fields[key]=None
-        remaining_unused=list(set(unused_field_names)-set(mapped_fields.values()))
-        return mapped_fields, remaining_unused
+    def __init__(self, required_fields, required_alternate_fields,
+        optional_fields, optional_alternate_fields):
+        self.required_fields = required_fields
+        self.required_alternate_fields = required_alternate_fields
+        self.optional_fields = optional_fields
+        self.optional_alternate_fields = optional_alternate_fields
 
     def transform_and_save_data(self, df, mapped_fields, selected_optional_fields, selected_additional_fields):
         st.subheader("Transform Data")
@@ -69,35 +22,25 @@ class SpecimenMetadataPage:
                 st.success(
                     f"Specimen Information has been saved!")
             except Exception as e:
-                st.error(f"Error saving Microhaplotype Information: {e}")
+                st.error(f"Error saving Specimen Information: {e}")
 
     def run(self):
-        # File upload
-        uploaded_file = self.upload_csv()
-        if uploaded_file:
-            df = load_csv(uploaded_file)
-            interactive_preview = st.toggle("Preview File")
-            if interactive_preview:
-                st.write("Uploaded File Preview:")
-                st.dataframe(df)
-
-            mapped_fields, unused_field_names = self.field_mapping(df)
-            # Add optional fields
-            selected_optional_fields, unused_field_names = self.add_optional_fields(df,
-                unused_field_names)
-            # Add additional fields
-            selected_additional_fields = self.add_additional_fields(unused_field_names)
-
-            # Transform and save data
-            self.transform_and_save_data(
-                df, mapped_fields, selected_optional_fields, selected_additional_fields)
-
+        df, mapped_fields, selected_optional_fields, selected_additional_fields=load_data(
+            required_fields, required_alternate_fields, optional_fields,
+            optional_alternate_fields)
+        # Transform and save data
+        if mapped_fields:
+            self.transform_and_save_data(df, mapped_fields,
+                selected_optional_fields, selected_additional_fields)
 
 if __name__ == "__main__":
     render_header()
     st.subheader("Specimen Level Metadata Converter", divider="gray")
     schema_fields = load_schema()
-    target_schema = schema_fields["specimen_level_metadata"]["required"]
-    alternate_schema_names = schema_fields["specimen_level_metadata"]["required_alternatives"]
-    app = SpecimenMetadataPage(target_schema, alternate_schema_names)
+    required_fields = schema_fields["specimen_level_metadata"]["required"]
+    required_alternate_fields = schema_fields["specimen_level_metadata"]["required_alternatives"]
+    optional_fields = schema_fields["specimen_level_metadata"]["optional"]
+    optional_alternate_fields = schema_fields["specimen_level_metadata"]["optional_alternatives"]
+    app = SpecimenMetadataPage(required_fields, required_alternate_fields,
+        optional_fields, optional_alternate_fields)
     app.run()

--- a/pages/2_Specimen_Level_Metadata.py
+++ b/pages/2_Specimen_Level_Metadata.py
@@ -16,35 +16,34 @@ class SpecimenMetadataPage:
         return st.file_uploader("Upload a TSV file", type=["csv", "tsv", "xlsx", "xls", "txt"])
 
     def field_mapping(self, df):
-        # Fuzzy field matching
-        field_mapping, unused_field_names = fuzzy_field_matching_page_section(
+        # Fuzzy field matching required arguments
+        mapped_fields, unused_field_names = fuzzy_field_matching_page_section(
             df, self.target_schema, self.alternate_schema_names)
 
         # Interactive field mapping
-        field_mapping = interactive_field_mapping_page_section(
-            field_mapping, df.columns.tolist())
-        return field_mapping, unused_field_names
+        mapped_fields = interactive_field_mapping_page_section(
+            mapped_fields, df.columns.tolist())
+        return mapped_fields, unused_field_names
 
-    def add_additional_fields(self, unused_field_names):
+    def add_additional_fields(self, df, unused_field_names):
         st.subheader("Add Additional Fields")
         selected_additional_fields = None
         if unused_field_names:
-            optional_additional_fields = st.toggle("Add additional fields")
-            if optional_additional_fields:
-                checkbox_states = {}
-                st.write("Select the extra columns you would like to include:")
-                for item in unused_field_names:
-                    checkbox_states[item] = st.checkbox(label=item)
-                selected_additional_fields = [
-                    key for key, value in checkbox_states.items() if value]
-                st.write("You selected:", selected_additional_fields)
-        return selected_additional_fields
+            # Fuzzy field matching optional arguments
+            mapped_fields, unused_field_names = fuzzy_field_matching_page_section(
+                df, schema_fields["specimen_level_metadata"]["optional"], 
+                schema_fields["specimen_level_metadata"]["optional_alternatives"])
 
-    def transform_and_save_data(self, df, field_mapping, selected_additional_fields):
+            #Interactive field mapping optional arguments
+            #mapped_fields = interactive_field_mapping_page_section(
+                #mapped_fields, df.columns.tolist())
+        return mapped_fields
+
+    def transform_and_save_data(self, df, mapped_fields, selected_additional_fields):
         st.subheader("Transform Data")
         if st.button("Transform Data"):
             transformed_df = transform_specimen_info(
-                df, field_mapping, selected_additional_fields)
+                df, mapped_fields, selected_additional_fields)
             st.session_state["specimen_info"] = transformed_df
             try:
                 st.success(
@@ -62,15 +61,15 @@ class SpecimenMetadataPage:
                 st.write("Uploaded File Preview:")
                 st.dataframe(df)
 
-            field_mapping, unused_field_names = self.field_mapping(df)
+            mapped_fields, unused_field_names = self.field_mapping(df)
 
             # Add additional fields
-            selected_additional_fields = self.add_additional_fields(
+            selected_additional_fields = self.add_additional_fields(df,
                 unused_field_names)
 
             # Transform and save data
             self.transform_and_save_data(
-                df, field_mapping, selected_additional_fields)
+                df, mapped_fields, selected_additional_fields)
 
 
 if __name__ == "__main__":
@@ -78,6 +77,6 @@ if __name__ == "__main__":
     st.subheader("Specimen Level Metadata Converter", divider="gray")
     schema_fields = load_schema()
     target_schema = schema_fields["specimen_level_metadata"]["required"]
-    alternate_schema_names = schema_fields["specimen_level_metadata"]["alternatives"]
+    alternate_schema_names = schema_fields["specimen_level_metadata"]["required_alternatives"]
     app = SpecimenMetadataPage(target_schema, alternate_schema_names)
     app.run()

--- a/pages/2_Specimen_Level_Metadata.py
+++ b/pages/2_Specimen_Level_Metadata.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from src.format_page import render_header
 from src.data_loader import load_csv
-from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section, interactive_field_mapping_page_section_optional
+from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section
 from src.transformer import transform_specimen_info
 from src.utils import load_schema
 
@@ -51,8 +51,8 @@ class SpecimenMetadataPage:
                 schema_fields["specimen_level_metadata"]["optional_alternatives"])
 
             #Interactive field mapping optional arguments
-            mapped_fields = interactive_field_mapping_page_section_optional(
-                mapped_fields, new_df.columns.tolist())
+            mapped_fields = interactive_field_mapping_page_section(
+                mapped_fields, new_df.columns.tolist(), "Manually Alter Field Mapping of optional arguments")
         for key in mapped_fields:
             if mapped_fields[key]=='no match':
                 mapped_fields[key]=None

--- a/pages/2_Specimen_Level_Metadata.py
+++ b/pages/2_Specimen_Level_Metadata.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from src.format_page import render_header
 from src.data_loader import load_csv
-from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section
+from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section, interactive_field_mapping_page_section_optional
 from src.transformer import transform_specimen_info
 from src.utils import load_schema
 
@@ -25,25 +25,45 @@ class SpecimenMetadataPage:
             mapped_fields, df.columns.tolist())
         return mapped_fields, unused_field_names
 
-    def add_additional_fields(self, df, unused_field_names):
+    def add_additional_fields(self, unused_field_names):
         st.subheader("Add Additional Fields")
         selected_additional_fields = None
         if unused_field_names:
+            optional_additional_fields = st.toggle("Add additional fields")
+            if optional_additional_fields:
+                checkbox_states = {}
+                st.write("Select the extra columns you would like to include:")
+                for item in unused_field_names:
+                    checkbox_states[item] = st.checkbox(label=item)
+                selected_additional_fields = [
+                    key for key, value in checkbox_states.items() if value]
+                st.write("You selected:", selected_additional_fields)
+        return selected_additional_fields
+
+    def add_optional_fields(self, df, unused_field_names):
+        st.subheader("Add Optional Fields")
+        mapped_fields = {key:None for key in schema_fields["specimen_level_metadata"]["optional"]}
+        if unused_field_names:
+            new_df=df[unused_field_names]
             # Fuzzy field matching optional arguments
-            mapped_fields, unused_field_names = fuzzy_field_matching_page_section(
-                df, schema_fields["specimen_level_metadata"]["optional"], 
+            mapped_fields, junk = fuzzy_field_matching_page_section(
+                new_df, schema_fields["specimen_level_metadata"]["optional"], 
                 schema_fields["specimen_level_metadata"]["optional_alternatives"])
 
             #Interactive field mapping optional arguments
-            #mapped_fields = interactive_field_mapping_page_section(
-                #mapped_fields, df.columns.tolist())
-        return mapped_fields
+            mapped_fields = interactive_field_mapping_page_section_optional(
+                mapped_fields, new_df.columns.tolist())
+        for key in mapped_fields:
+            if mapped_fields[key]=='no match':
+                mapped_fields[key]=None
+        remaining_unused=list(set(unused_field_names)-set(mapped_fields.values()))
+        return mapped_fields, remaining_unused
 
-    def transform_and_save_data(self, df, mapped_fields, selected_additional_fields):
+    def transform_and_save_data(self, df, mapped_fields, selected_optional_fields, selected_additional_fields):
         st.subheader("Transform Data")
         if st.button("Transform Data"):
             transformed_df = transform_specimen_info(
-                df, mapped_fields, selected_additional_fields)
+                df, mapped_fields, selected_optional_fields, selected_additional_fields)
             st.session_state["specimen_info"] = transformed_df
             try:
                 st.success(
@@ -62,14 +82,15 @@ class SpecimenMetadataPage:
                 st.dataframe(df)
 
             mapped_fields, unused_field_names = self.field_mapping(df)
-
-            # Add additional fields
-            selected_additional_fields = self.add_additional_fields(df,
+            # Add optional fields
+            selected_optional_fields, unused_field_names = self.add_optional_fields(df,
                 unused_field_names)
+            # Add additional fields
+            selected_additional_fields = self.add_additional_fields(unused_field_names)
 
             # Transform and save data
             self.transform_and_save_data(
-                df, mapped_fields, selected_additional_fields)
+                df, mapped_fields, selected_optional_fields, selected_additional_fields)
 
 
 if __name__ == "__main__":

--- a/pages/3_Experiment_Level_Metadata.py
+++ b/pages/3_Experiment_Level_Metadata.py
@@ -1,83 +1,47 @@
 import streamlit as st
 from src.format_page import render_header
-from src.data_loader import load_csv
-from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section
+from src.field_matcher import load_data
 from src.transformer import transform_experiment_info
 from src.utils import load_schema
 
 
 class ExperimentMetadataPage:
-    def __init__(self, target_schema, alternate_schema_names):
-        self.target_schema = target_schema
-        self.alternate_schema_names = alternate_schema_names
+    def __init__(self, required_fields, required_alternate_fields,
+        optional_fields, optional_alternate_fields):
+        self.required_fields = required_fields
+        self.required_alternate_fields = required_alternate_fields
+        self.optional_fields = optional_fields
+        self.optional_alternate_fields = optional_alternate_fields
 
-    def upload_csv(self):
-        st.subheader("Upload File")
-        return st.file_uploader("Upload a TSV file", type=["csv", "tsv", "xlsx", "xls", "txt"])
-
-    def field_mapping(self, df):
-        # Fuzzy field matching
-        field_mapping, unused_field_names = fuzzy_field_matching_page_section(
-            df, self.target_schema, self.alternate_schema_names)
-
-        # Interactive field mapping
-        field_mapping = interactive_field_mapping_page_section(
-            field_mapping, df.columns.tolist())
-        return field_mapping, unused_field_names
-
-    def add_additional_fields(self, unused_field_names):
-        st.subheader("Add Additional Fields")
-        selected_additional_fields = None
-        if unused_field_names:
-            optional_additional_fields = st.toggle("Add additional fields")
-            if optional_additional_fields:
-                checkbox_states = {}
-                st.write("Select the extra columns you would like to include:")
-                for item in unused_field_names:
-                    checkbox_states[item] = st.checkbox(label=item)
-                selected_additional_fields = [
-                    key for key, value in checkbox_states.items() if value]
-                st.write("You selected:", selected_additional_fields)
-        return selected_additional_fields
-
-    def transform_and_save_data(self, df, field_mapping, selected_additional_fields):
+    def transform_and_save_data(self, df, field_mapping, 
+        selected_optional_fields, selected_additional_fields):
         st.subheader("Transform Data")
         if st.button("Transform Data"):
-            transformed_df = transform_experiment_info(
-                df, field_mapping, selected_additional_fields)
+            transformed_df = transform_experiment_info(df, field_mapping,
+                selected_optional_fields, selected_additional_fields)
             st.session_state["experiment_info"] = transformed_df
             try:
                 st.success(
-                    f"Specimen Information has been saved!")
+                    f"Experiment Information has been saved!")
             except Exception as e:
-                st.error(f"Error saving Microhaplotype Information: {e}")
+                st.error(f"Error saving Experiment Information: {e}")
 
     def run(self):
         # File upload
-        uploaded_file = self.upload_csv()
-        if uploaded_file:
-            df = load_csv(uploaded_file)
-            interactive_preview = st.toggle("Preview File")
-            if interactive_preview:
-                st.write("Uploaded File Preview:")
-                st.dataframe(df)
-
-            field_mapping, unused_field_names = self.field_mapping(df)
-
-            # Add additional fields
-            selected_additional_fields = self.add_additional_fields(
-                unused_field_names)
-
+        df, mapped_fields, selected_optional_fields, selected_additional_fields=load_data(
+            required_fields, required_alternate_fields, optional_fields,
+            optional_alternate_fields)
             # Transform and save data
-            self.transform_and_save_data(
-                df, field_mapping, selected_additional_fields)
-
+        self.transform_and_save_data(df, mapped_fields,
+            selected_optional_fields, selected_additional_fields)
 
 if __name__ == "__main__":
     render_header()
     st.subheader("Experiment Level Metadata Converter", divider="gray")
     schema_fields = load_schema()
-    target_schema = schema_fields["experiment_level_metadata"]["required"]
-    alternate_schema_names = schema_fields["experiment_level_metadata"]["alternatives"]
-    app = ExperimentMetadataPage(target_schema, alternate_schema_names)
+    required_fields = schema_fields["experiment_level_metadata"]["required"]
+    required_alternate_fields = schema_fields["experiment_level_metadata"]["required_alternatives"]
+    optional_fields = schema_fields["experiment_level_metadata"]["optional"]
+    optional_alternate_fields = schema_fields["experiment_level_metadata"]["optional_alternatives"]
+    app = ExperimentMetadataPage(required_fields, required_alternate_fields, optional_fields, optional_alternate_fields)
     app.run()

--- a/pages/3_Experiment_Level_Metadata.py
+++ b/pages/3_Experiment_Level_Metadata.py
@@ -4,6 +4,8 @@ from src.field_matcher import load_data
 from src.transformer import transform_experiment_info
 from src.utils import load_schema
 
+session_name="experiment_info"
+title='experiment level metadata'
 
 class ExperimentMetadataPage:
     def __init__(self, required_fields, required_alternate_fields,
@@ -13,18 +15,26 @@ class ExperimentMetadataPage:
         self.optional_fields = optional_fields
         self.optional_alternate_fields = optional_alternate_fields
 
-    def transform_and_save_data(self, df, field_mapping, 
+    def transform_and_save_data(self, df, mapped_fields, 
         selected_optional_fields, selected_additional_fields):
-        st.subheader("Transform Data")
-        if st.button("Transform Data"):
-            transformed_df = transform_experiment_info(df, field_mapping,
-                selected_optional_fields, selected_additional_fields)
-            st.session_state["experiment_info"] = transformed_df
-            try:
-                st.success(
-                    f"Experiment Information has been saved!")
-            except Exception as e:
-                st.error(f"Error saving Experiment Information: {e}")
+        if mapped_fields and selected_optional_fields!='Error':
+            st.subheader("Transform Data")
+            if st.button("Transform Data"):
+                transformed_df = transform_experiment_info(df, mapped_fields,
+                    selected_optional_fields, selected_additional_fields)
+                st.session_state["experiment_info"] = transformed_df
+                try:
+                    st.success(
+                        f"Experiment Information has been saved!")
+                except Exception as e:
+                    st.error(f"Error saving Experiment Information: {e}")
+
+    def display_panel_info(self, toggle_text):
+        if session_name in st.session_state:
+            preview = st.toggle(toggle_text)
+            if preview:
+                st.write(f"Current {title}:")
+                st.json(st.session_state[session_name])
 
     def run(self):
         # File upload
@@ -34,6 +44,8 @@ class ExperimentMetadataPage:
             # Transform and save data
         self.transform_and_save_data(df, mapped_fields,
             selected_optional_fields, selected_additional_fields)
+        # Display current panel information
+        self.display_panel_info(f"Preview {title}")
 
 if __name__ == "__main__":
     render_header()
@@ -44,4 +56,8 @@ if __name__ == "__main__":
     optional_fields = schema_fields["experiment_level_metadata"]["optional"]
     optional_alternate_fields = schema_fields["experiment_level_metadata"]["optional_alternatives"]
     app = ExperimentMetadataPage(required_fields, required_alternate_fields, optional_fields, optional_alternate_fields)
+    if session_name in st.session_state:
+        st.success(f'Your {title} has already been saved during a'
+            ' previous run of this page')
+        app.display_panel_info(f"Preview previously stored {title}")
     app.run()

--- a/pages/4_Microhaplotype_Information.py
+++ b/pages/4_Microhaplotype_Information.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from src.data_loader import load_csv
+from src.field_matcher import load_data
 from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section
 from src.transformer import transform_mhap_info
 from src.format_page import render_header
@@ -7,49 +7,27 @@ from src.utils import load_schema
 
 
 class MhapPage:
-    def __init__(self, target_schema, alternate_schema_names):
-        self.target_schema = target_schema
-        self.alternate_schema_names = alternate_schema_names
-
-    def upload_csv(self):
-        st.subheader("Upload File")
-        return st.file_uploader("Upload a TSV file", type=["csv", "tsv", "xlsx", "xls", "txt"])
-
-    def field_mapping(self, df):
-        # Fuzzy field matching
-        field_mapping, unused_field_names = fuzzy_field_matching_page_section(
-            df, self.target_schema, self.alternate_schema_names)
-
-        # Interactive field mapping
-        field_mapping = interactive_field_mapping_page_section(
-            field_mapping, df.columns.tolist())
-        return field_mapping, unused_field_names
-
-    def add_additional_fields(self, unused_field_names):
-        st.subheader("Add Additional Fields")
-        selected_additional_fields = None
-        if unused_field_names:
-            optional_additional_fields = st.toggle("Add additional fields")
-            if optional_additional_fields:
-                checkbox_states = {}
-                st.write("Select the extra columns you would like to include:")
-                for item in unused_field_names:
-                    checkbox_states[item] = st.checkbox(label=item)
-                selected_additional_fields = [
-                    key for key, value in checkbox_states.items() if value]
-                st.write("You selected:", selected_additional_fields)
-        return selected_additional_fields
+    def __init__(self, required_fields, required_alternate_fields,
+        optional_fields, optional_alternate_fields):
+        self.required_fields = required_fields
+        self.required_alternate_fields = required_alternate_fields
+        self.optional_fields = optional_fields
+        self.optional_alternate_fields = optional_alternate_fields
 
     def bioinfo_id_input(self):
         st.subheader("Bioinformatics ID")
         return st.text_input("Enter bioinfo ID:", help='Identifier for the bioinformatics run.')
 
-    def transform_and_save_data(self, df, bioinfo_ID, field_mapping, selected_additional_fields):
+    def transform_and_save_data(self, df, bioinfo_ID, field_mapping, 
+        selected_optional_fields, selected_additional_fields):
+        #there are currently no optional fields but the field is passed anyway
+        #for compatibility with any future optional fields.
         if bioinfo_ID:
             st.subheader("Transform Data")
             if st.button("Transform Data"):
-                transformed_df = transform_mhap_info(
-                    df, bioinfo_ID, field_mapping, selected_additional_fields)
+                transformed_df = transform_mhap_info(df, bioinfo_ID,
+                    field_mapping, selected_optional_fields,
+                    selected_additional_fields)
                 # json_data = json.dumps(transformed_df, indent=4)
                 st.session_state["mhap_data"] = transformed_df
                 try:
@@ -60,33 +38,24 @@ class MhapPage:
 
     def run(self):
         # File upload
-        uploaded_file = self.upload_csv()
-        if uploaded_file:
-            df = load_csv(uploaded_file)
-            interactive_preview = st.toggle("Preview File")
-            if interactive_preview:
-                st.write("Uploaded File Preview:")
-                st.dataframe(df)
-
-            field_mapping, unused_field_names = self.field_mapping(df)
-
-            # Add additional fields
-            selected_additional_fields = self.add_additional_fields(
-                unused_field_names)
-
+        df, mapped_fields, selected_optional_fields, selected_additional_fields=load_data(
+            required_fields, required_alternate_fields, optional_fields,
+            optional_alternate_fields)
             # Enter bioinformatics ID
-            bioinfo_ID = self.bioinfo_id_input()
-
-            self.transform_and_save_data(
-                df, bioinfo_ID, field_mapping, selected_additional_fields)
-
+        bioinfo_ID = self.bioinfo_id_input()
+        self.transform_and_save_data(
+            df, bioinfo_ID, mapped_fields, selected_optional_fields, selected_additional_fields)
 
 # Initialize and run the app
 if __name__ == "__main__":
     render_header()
     st.subheader("Microhaplotype Information Converter", divider="gray")
     schema_fields = load_schema()
-    target_schema = schema_fields["mhap_info"]["required"]
-    alternate_schema_names = schema_fields["mhap_info"]["alternatives"]
-    app = MhapPage(target_schema, alternate_schema_names)
+
+    required_fields = schema_fields["mhap_info"]["required"]
+    required_alternate_fields = schema_fields["mhap_info"]["required_alternatives"]
+    optional_fields = schema_fields["mhap_info"]["optional"]
+    optional_alternate_fields = schema_fields["mhap_info"]["optional_alternatives"]
+    app = MhapPage(required_fields, required_alternate_fields, optional_fields,
+        optional_alternate_fields)
     app.run()

--- a/pages/5_Demultiplexed_Samples.py
+++ b/pages/5_Demultiplexed_Samples.py
@@ -24,7 +24,7 @@ class DemultiplexPage:
             st.subheader("Transform Data")
             if st.button("Transform Data"):
                 transformed_df = transform_demultiplexed_info(
-                    df, bioinfo_ID, mapped_fields, selected_additional_fields)
+                    df, bioinfo_ID, mapped_fields, selected_optional_fields, selected_additional_fields)
                 st.session_state["demultiplexed_data"] = transformed_df
                 try:
                     st.success(

--- a/pages/5_Demultiplexed_Samples.py
+++ b/pages/5_Demultiplexed_Samples.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from src.data_loader import load_csv
+from src.field_matcher import load_data
 from src.field_matcher import fuzzy_field_matching_page_section, interactive_field_mapping_page_section
 from src.transformer import transform_demultiplexed_info
 from src.format_page import render_header
@@ -7,49 +7,24 @@ from src.utils import load_schema
 
 
 class DemultiplexPage:
-    def __init__(self, target_schema, alternate_schema_names):
-        self.target_schema = target_schema
-        self.alternate_schema_names = alternate_schema_names
-
-    def upload_csv(self):
-        st.subheader("Upload File")
-        return st.file_uploader("Upload a TSV file", type=["csv", "tsv", "xlsx", "xls", "txt"])
-
-    def field_mapping(self, df):
-        # Fuzzy field matching
-        field_mapping, unused_field_names = fuzzy_field_matching_page_section(
-            df, self.target_schema, self.alternate_schema_names)
-
-        # Interactive field mapping
-        field_mapping = interactive_field_mapping_page_section(
-            field_mapping, df.columns.tolist())
-        return field_mapping, unused_field_names
-
-    def add_additional_fields(self, unused_field_names):
-        st.subheader("Add Additional Fields")
-        selected_additional_fields = None
-        if unused_field_names:
-            optional_additional_fields = st.toggle("Add additional fields")
-            if optional_additional_fields:
-                checkbox_states = {}
-                st.write("Select the extra columns you would like to include:")
-                for item in unused_field_names:
-                    checkbox_states[item] = st.checkbox(label=item)
-                selected_additional_fields = [
-                    key for key, value in checkbox_states.items() if value]
-                st.write("You selected:", selected_additional_fields)
-        return selected_additional_fields
+    def __init__(self, required_fields, required_alternate_fields,
+        optional_fields, optional_alternate_fields):
+        self.required_fields = required_fields
+        self.required_alternate_fields = required_alternate_fields
+        self.optional_fields = optional_fields
+        self.optional_alternate_fields = optional_alternate_fields
 
     def bioinfo_id_input(self):
         st.subheader("Bioinformatics ID")
         return st.text_input("Enter bioinfo ID:", help='Identifier for the bioinformatics run.')
 
-    def transform_and_save_data(self, df, bioinfo_ID, field_mapping, selected_additional_fields):
+    def transform_and_save_data(self, df, bioinfo_ID, mapped_fields,
+        selected_optional_fields, selected_additional_fields):
         if bioinfo_ID:
             st.subheader("Transform Data")
             if st.button("Transform Data"):
                 transformed_df = transform_demultiplexed_info(
-                    df, bioinfo_ID, field_mapping, selected_additional_fields)
+                    df, bioinfo_ID, mapped_fields, selected_additional_fields)
                 st.session_state["demultiplexed_data"] = transformed_df
                 try:
                     st.success(
@@ -59,33 +34,24 @@ class DemultiplexPage:
 
     def run(self):
         # File upload
-        uploaded_file = self.upload_csv()
-        if uploaded_file:
-            df = load_csv(uploaded_file)
-            interactive_preview = st.toggle("Preview File")
-            if interactive_preview:
-                st.write("Uploaded File Preview:")
-                st.dataframe(df)
-
-            field_mapping, unused_field_names = self.field_mapping(df)
-
-            # Add additional fields
-            selected_additional_fields = self.add_additional_fields(
-                unused_field_names)
-
-            # Enter bioinformatics ID
-            bioinfo_ID = self.bioinfo_id_input()
-
-            self.transform_and_save_data(
-                df, bioinfo_ID, field_mapping, selected_additional_fields)
-
+        df, mapped_fields, selected_optional_fields, selected_additional_fields=load_data(
+            required_fields, required_alternate_fields, optional_fields,
+            optional_alternate_fields)
+        # Enter bioinformatics ID
+        bioinfo_ID = self.bioinfo_id_input()
+        self.transform_and_save_data(
+            df, bioinfo_ID, mapped_fields, selected_optional_fields,
+            selected_additional_fields)
 
 # Initialize and run the app
 if __name__ == "__main__":
     render_header()
     st.subheader("Demultiplexed Sample Read Count Converter", divider="gray")
     schema_fields = load_schema()
-    target_schema = schema_fields["demultiplexed_samples"]["required"]
-    alternate_schema_names = schema_fields["demultiplexed_samples"]["alternatives"]
-    app = DemultiplexPage(target_schema, alternate_schema_names)
+    required_fields = schema_fields["demultiplexed_samples"]["required"]
+    required_alternate_fields = schema_fields["demultiplexed_samples"]["required_alternatives"]
+    optional_fields = schema_fields["demultiplexed_samples"]["optional"]
+    optional_alternate_fields = schema_fields["demultiplexed_samples"]["optional_alternatives"]
+    app = DemultiplexPage(required_fields, required_alternate_fields,
+        optional_fields, optional_alternate_fields)
     app.run()

--- a/pages/5_Demultiplexed_Samples.py
+++ b/pages/5_Demultiplexed_Samples.py
@@ -5,6 +5,8 @@ from src.transformer import transform_demultiplexed_info
 from src.format_page import render_header
 from src.utils import load_schema
 
+session_name="demultiplexed_data"
+title='demultiplexed samples'
 
 class DemultiplexPage:
     def __init__(self, required_fields, required_alternate_fields,
@@ -20,7 +22,7 @@ class DemultiplexPage:
 
     def transform_and_save_data(self, df, bioinfo_ID, mapped_fields,
         selected_optional_fields, selected_additional_fields):
-        if bioinfo_ID:
+        if bioinfo_ID and mapped_fields and selected_optional_fields!='Error':
             st.subheader("Transform Data")
             if st.button("Transform Data"):
                 transformed_df = transform_demultiplexed_info(
@@ -30,7 +32,14 @@ class DemultiplexPage:
                     st.success(
                         f"Demultiplexed Information from Bioinformatics Run '{bioinfo_ID}' has been saved!")
                 except Exception as e:
-                    st.error(f"Error saving Microhaplotype Information: {e}")
+                    st.error(f"Error saving demultiplexed samples: {e}")
+
+    def display_panel_info(self, toggle_text):
+        if session_name in st.session_state:
+            preview = st.toggle(toggle_text)
+            if preview:
+                st.write(f"Current {title}:")
+                st.json(st.session_state[session_name])
 
     def run(self):
         # File upload
@@ -42,6 +51,9 @@ class DemultiplexPage:
         self.transform_and_save_data(
             df, bioinfo_ID, mapped_fields, selected_optional_fields,
             selected_additional_fields)
+        # Display current panel information
+        self.display_panel_info(f"Preview {title}")
+
 
 # Initialize and run the app
 if __name__ == "__main__":
@@ -54,4 +66,8 @@ if __name__ == "__main__":
     optional_alternate_fields = schema_fields["demultiplexed_samples"]["optional_alternatives"]
     app = DemultiplexPage(required_fields, required_alternate_fields,
         optional_fields, optional_alternate_fields)
+    if session_name in st.session_state:
+        st.success(f'Your {title} has already been saved during a'
+            ' previous run of this page')
+        app.display_panel_info(f"Preview previously stored {title}")
     app.run()

--- a/src/field_matcher.py
+++ b/src/field_matcher.py
@@ -147,15 +147,34 @@ def add_optional_fields(df, unused_field_names, optional_schema,
 #        data = [{"user_column": key, "PMO Argument": value}
 #        for key, value in reverse_field_mapping.items()]
 #        df = pd.DataFrame(data)
-        st.write("Suggested Field Mapping. Check the boxes of any fields you"
-            " would like to inclue in the final PMO. You will have the"
-            " opportunity to optionally change their mappings if any of these"
-            " mappings look inaccurate:")
+        st.write('Some of the fields in your table may match to one of our'
+            ' suggested "optional fields".')
+        st.write('Check the boxes of any fields you would like to include in'
+            ' the final PMO.')
+        st.write('You can edit these mappings or include them without mapping'
+            " them to any of the suggested fields.")
+        st.write('Our suggested mappings are below, with your column name on'
+            ' the lefthand side and the suggested optional field name on the'
+            ' right.')
+
 #        st.dataframe(df)
         checkbox_states = {}
         for user_column in reverse_field_mapping:
             pmo_argument=reverse_field_mapping[user_column]
             checkbox_states[user_column] = st.checkbox(label=f'{user_column} --> {pmo_argument}')
+        st.subheader("Edit Selected Optional Field Mappings")
+        updated_mapping={}
+        for user_column in checkbox_states:
+            pmo_argument=reverse_field_mapping[user_column]
+            if checkbox_states[user_column]:
+                edit_column = st.toggle(f"Edit {user_column} --> {pmo_argument} mapping")
+                if edit_column:
+                    updated_mapping[user_column] = st.selectbox(
+                    f"Select optional argument match for {user_column}",
+                    options=optional_schema, index=optional_schema.index(
+                    user_column) if user_column in optional_schema else 0)
+                    no_map=st.checkbox(label=f'{user_column} has no good "optional argument" match but I still want to include it in the final PMO')
+
         #selected_additional_fields = [
         #    key for key, value in checkbox_states.items() if value]
 

--- a/src/field_matcher.py
+++ b/src/field_matcher.py
@@ -133,9 +133,9 @@ def add_optional_fields(df, unused_field_names, optional_schema,
     return mapped_fields, remaining_unused
 
 def add_additional_fields(unused_field_names):
-    st.subheader("Add Additional Fields")
     selected_additional_fields = None
     if unused_field_names:
+        st.subheader("Add Additional Fields")
         optional_additional_fields = st.toggle("Add additional fields")
         if optional_additional_fields:
             checkbox_states = {}

--- a/src/field_matcher.py
+++ b/src/field_matcher.py
@@ -54,8 +54,9 @@ def check_for_duplicates(field_mapping):
     if 'no match' in duplicates:
         duplicates.remove('no match')
     if duplicates:
-        raise ValueError(
-            f"Duplicate target schema fields found: {duplicates}")
+        st.error(f"Duplicate target schema fields found: {duplicates}")
+#        raise ValueError(
+ #           f"Duplicate target schema fields found: {duplicates}")
 
     return True
 
@@ -115,9 +116,9 @@ def interactive_field_mapping_page_section(field_mapping, df_columns, toggle_nam
 
 def add_optional_fields(df, unused_field_names, optional_schema,
     optional_alternate_schema):
-    st.subheader("Add Optional Fields")
     mapped_fields = {key:None for key in optional_schema}
-    if unused_field_names:
+    if unused_field_names and optional_schema:
+        st.subheader("Add Optional Fields")
         new_df=df[unused_field_names]
         # Fuzzy field matching optional arguments
         mapped_fields, junk = fuzzy_field_matching_page_section(new_df,

--- a/src/field_matcher.py
+++ b/src/field_matcher.py
@@ -99,23 +99,10 @@ def fuzzy_field_matching_page_section(df, target_schema, alternate_schema_names=
     return field_mapping, unused_field_names
 
 
-def interactive_field_mapping_page_section(field_mapping, df_columns):
+def interactive_field_mapping_page_section(field_mapping, df_columns, toggle_name="Manually Alter Field Mapping"):
     df_columns+=['no match']
     interactive_field_mapping_on = st.toggle(
-        "Manually Alter Field Mapping")
-    if interactive_field_mapping_on:
-        updated_mapping = interactive_field_mapping(
-            field_mapping, df_columns)
-        st.write("Updated Field Mapping:")
-        st.dataframe(field_mapping_json_to_table(updated_mapping))
-        check_for_duplicates(updated_mapping)
-        return updated_mapping
-    return field_mapping
-
-def interactive_field_mapping_page_section_optional(field_mapping, df_columns):
-    df_columns+=['no match']
-    interactive_field_mapping_on = st.toggle(
-        "Manually Alter Field Mapping of optional arguments")
+        toggle_name)
     if interactive_field_mapping_on:
         updated_mapping = interactive_field_mapping(
             field_mapping, df_columns)

--- a/src/field_matcher.py
+++ b/src/field_matcher.py
@@ -33,9 +33,8 @@ def fuzzy_match_fields(field_names, target_schema, alternate_schema_names=None):
         best_match_field = best_match[0]
         matches[target] = best_match_field
     # Find unused field names
-    unused_field_names = [f for f in field_names if f not in matches]
+    unused_field_names = list(set(field_names)-set(matches.values()))
     return matches, unused_field_names
-
 
 def check_for_duplicates(field_mapping):
     """
@@ -51,6 +50,8 @@ def check_for_duplicates(field_mapping):
     counts = Counter(list(field_mapping.values()))
     duplicates = {item for item, count in counts.items() if count > 1}
     # Check for duplicates by comparing the length of the list to the length of the set
+    if 'no match' in duplicates:
+        duplicates.remove('no match')
     if duplicates:
         raise ValueError(
             f"Duplicate target schema fields found: {duplicates}")
@@ -99,8 +100,22 @@ def fuzzy_field_matching_page_section(df, target_schema, alternate_schema_names=
 
 
 def interactive_field_mapping_page_section(field_mapping, df_columns):
+    df_columns+=['no match']
     interactive_field_mapping_on = st.toggle(
         "Manually Alter Field Mapping")
+    if interactive_field_mapping_on:
+        updated_mapping = interactive_field_mapping(
+            field_mapping, df_columns)
+        st.write("Updated Field Mapping:")
+        st.dataframe(field_mapping_json_to_table(updated_mapping))
+        check_for_duplicates(updated_mapping)
+        return updated_mapping
+    return field_mapping
+
+def interactive_field_mapping_page_section_optional(field_mapping, df_columns):
+    df_columns+=['no match']
+    interactive_field_mapping_on = st.toggle(
+        "Manually Alter Field Mapping of optional arguments")
     if interactive_field_mapping_on:
         updated_mapping = interactive_field_mapping(
             field_mapping, df_columns)

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -24,7 +24,8 @@ def transform_panel_info(df, panel_id, field_mapping, target_genome_info, additi
     return transformed_df
 
 
-def transform_specimen_info(df, field_mapping, additional_fields=None):
+def transform_specimen_info(df, field_mapping, optional_field_mapping, additional_fields=None):
+    print('optional field mapping is', optional_field_mapping)
     transformed_df = specimen_info_table_to_json(
         df,
         specimen_id_col=field_mapping["specimen_id"],
@@ -35,6 +36,18 @@ def transform_specimen_info(df, field_mapping, additional_fields=None):
         samp_store_loc=field_mapping["samp_store_loc"],
         samp_collect_device=field_mapping["samp_collect_device"],
         project_name=field_mapping["project_name"],
+        alternate_identifiers=optional_field_mapping['alternate_identifiers'],
+        geo_admin1=optional_field_mapping['geo_admin1'],
+        geo_admin2=optional_field_mapping['geo_admin2'],
+        geo_admin3=optional_field_mapping['geo_admin3'],
+        host_taxon_id=optional_field_mapping['host_taxon_id'],
+        individual_id=optional_field_mapping['individual_id'],
+        lat_lon=optional_field_mapping['lat_lon'],
+        parasite_density=optional_field_mapping['parasite_density'],
+        plate_col=optional_field_mapping['plate_col'],
+        plate_name=optional_field_mapping['plate_name'],
+        plate_row=optional_field_mapping['plate_row'],
+        sample_comments=optional_field_mapping['sample_comments'],
         additional_specimen_cols=additional_fields
     )
     return transformed_df

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -19,7 +19,7 @@ def transform_mhap_info(df, bioinfo_id, field_mapping, optional_mapping,
 
 
 def transform_panel_info(df, panel_id, field_mapping, target_genome_info,
-    additional_target_info_cols=None):
+    optional_fields, additional_target_info_cols=None):
     """Reformat the DataFrame based on the provided field mapping."""
     transformed_df = panel_info_table_to_pmo_dict(
         df,
@@ -28,6 +28,16 @@ def transform_panel_info(df, panel_id, field_mapping, target_genome_info,
         target_id_col=field_mapping["target_id"],
         forward_primers_seq_col=field_mapping["forward_primers"],
         reverse_primers_seq_col=field_mapping["reverse_primers"],
+        forward_primers_start_col=optional_fields["forward_primers_start_col"],
+        forward_primers_end_col=optional_fields["forward_primers_end_col"],
+        reverse_primers_start_col=optional_fields["reverse_primers_start_col"],
+        reverse_primers_end_col=optional_fields["reverse_primers_end_col"],
+        insert_start_col=optional_fields["insert_start_col"],
+        insert_end_col=optional_fields["insert_end_col"],
+        chrom_col=optional_fields["chrom_col"],
+        strand_col=optional_fields["strand_col"],
+        gene_id_col=optional_fields["gene_id_col"],
+        target_type_col=optional_fields["target_type_col"],
         additional_target_info_cols=additional_target_info_cols)
     return transformed_df
 

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -18,7 +18,8 @@ def transform_mhap_info(df, bioinfo_id, field_mapping, optional_mapping,
     return transformed_df
 
 
-def transform_panel_info(df, panel_id, field_mapping, target_genome_info, additional_target_info_cols=None):
+def transform_panel_info(df, panel_id, field_mapping, target_genome_info,
+    additional_target_info_cols=None):
     """Reformat the DataFrame based on the provided field mapping."""
     transformed_df = panel_info_table_to_pmo_dict(
         df,
@@ -31,7 +32,8 @@ def transform_panel_info(df, panel_id, field_mapping, target_genome_info, additi
     return transformed_df
 
 
-def transform_specimen_info(df, field_mapping, optional_field_mapping, additional_fields=None):
+def transform_specimen_info(df, field_mapping, optional_field_mapping,
+    additional_fields=None):
     print('optional field mapping is', optional_field_mapping)
     transformed_df = specimen_info_table_to_json(
         df,
@@ -76,7 +78,8 @@ def transform_experiment_info(df, field_mapping, optional_mapping,
     )
     return transformed_df
 
-def transform_demultiplexed_info(df, bioinfo_id, field_mapping, additional_hap_detected_cols=None):
+def transform_demultiplexed_info(df, bioinfo_id, field_mapping,
+    optional_mapping, additional_hap_detected_cols=None):
     """Reformat the DataFrame based on the provided field mapping."""
     transformed_df = demultiplexed_targets_to_pmo_dict(
         df,

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -4,10 +4,17 @@ from pmotools.json_convertors.metatable_to_json_meta import experiment_info_tabl
 from pmotools.json_convertors.demultiplexed_targets_to_pmo_dict import demultiplexed_targets_to_pmo_dict
 
 
-def transform_mhap_info(df, bioinfo_id, field_mapping, additional_hap_detected_cols=None):
+def transform_mhap_info(df, bioinfo_id, field_mapping, optional_mapping,
+    additional_hap_detected_cols=None):
     """Reformat the DataFrame based on the provided field mapping."""
     transformed_df = microhaplotype_table_to_pmo_dict(
-        df, bioinfo_id, sampleID_col=field_mapping["sampleID"], locus_col=field_mapping['target_id'], mhap_col=field_mapping['asv'], reads_col=field_mapping['reads'], additional_hap_detected_cols=additional_hap_detected_cols)
+        df,
+        bioinfo_id,
+        sampleID_col=field_mapping["sampleID"],
+        locus_col=field_mapping['target_id'],
+        mhap_col=field_mapping['asv'],
+        reads_col=field_mapping['reads'],
+        additional_hap_detected_cols=additional_hap_detected_cols)
     return transformed_df
 
 
@@ -72,5 +79,10 @@ def transform_experiment_info(df, field_mapping, optional_mapping,
 def transform_demultiplexed_info(df, bioinfo_id, field_mapping, additional_hap_detected_cols=None):
     """Reformat the DataFrame based on the provided field mapping."""
     transformed_df = demultiplexed_targets_to_pmo_dict(
-        df, bioinfo_id, sampleID_col=field_mapping["sampleID"], target_id_col=field_mapping['target_id'], read_count_col=field_mapping['raw_read_count'], additional_hap_detected_cols=additional_hap_detected_cols)
+        df,
+        bioinfo_id,
+        sampleID_col=field_mapping["sampleID"],
+        target_id_col=field_mapping['target_id'],
+        read_count_col=field_mapping['raw_read_count'],
+        additional_hap_detected_cols=additional_hap_detected_cols)
     return transformed_df

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -53,17 +53,21 @@ def transform_specimen_info(df, field_mapping, optional_field_mapping, additiona
     return transformed_df
 
 
-def transform_experiment_info(df, field_mapping, additional_fields=None):
+def transform_experiment_info(df, field_mapping, optional_mapping,
+    additional_fields=None):
     transformed_df = experiment_info_table_to_json(
         df,
         experiment_sample_id_col=field_mapping["experiment_sample_id"],
         sequencing_info_id=field_mapping["sequencing_info_id"],
         specimen_id=field_mapping["specimen_id"],
         panel_id=field_mapping["panel_id"],
+        accession=optional_mapping["accession"],
+        plate_col=optional_mapping["plate_col"],
+        plate_name=optional_mapping["plate_name"],
+        plate_row=optional_mapping["plate_row"],
         additional_experiment_cols=additional_fields
     )
     return transformed_df
-
 
 def transform_demultiplexed_info(df, bioinfo_id, field_mapping, additional_hap_detected_cols=None):
     """Reformat the DataFrame based on the provided field mapping."""


### PR DESCRIPTION
These commits add the following features:

1. Edited the schema so it has terminology for optional arguments and modified the corresponding page to pull the correct schema terms
2. Changed the variable name 'field mapping' to 'mapped fields' where it somewhat ambiguously refers to both a function and a dictionary (mostly to clarify my thinking process so I wouldn't think it was a recursive function)
3. Added a new function called add_optional_fields - this function takes unused fields as inputs, and if there are any, uses fuzzy and interactive mapping to map them to optional fields from the json schema. Allows user to select 'no match' as a checkbox
4. edited transform_and_save_data function to accept the optional mappings
5. edited the unused field names calculation for fuzzy_match_fields - the old version was grabbing unused field names from the schema, whereas what we wanted was unused column names from the metadata sheet.
6. edited the check for duplicates function to not throw an error if 'no matches' was found as a key - it's expected and not an issue if multiple optional columns are missing from the metadata and therefore share 'no match' as their mapped value.
7. Added a 'toggle_name' variable to the interactive_field_mapping_page_section function, with a default value. This is because in streamlit, two toggles can't share the same name on a single webpage, but I needed to call this function once for required variables and once for optional variables.
8. Modified transformer.py function to send out the field mapped value of each optional field mapping - to be consistent with the expected inputs of the specimen_info_table_to_json pmotools function on the other side.
9. added a 'reverse_fuzzy_match' function to map user columns to optional fields (outputs one match per user column rather than one match per expected PMO field)
10. added a 'preview' ability to pages 1-5, along with a message alerting users if a page already has pre-existing data associated with it.

Some changes for the future:
1. optional arguments are being handled a little bit oddly - when a user has a field name that matches imperfectly to an expected optional PMO field, the user's field name (rather than the matching optional PMO field) is what gets added to the final PMO. This is likely either an issue with the tranformer.py functions or the imported pmotools-python functions that transformer.py is using
2. the add_optional_fields function is too long and should probably be broken up
3. Several functions in the individual pages (e.g. everything related to 'display_panel_info' function) are boilerplate and should be moved to a centralized location.
